### PR TITLE
Fix Compilation Errors And Warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,13 +124,3 @@ pub mod math {
     pub mod yn;
     pub mod ynf;
 }
-
-
-
-// FIXME: Scuffed
-#[no_mangle]
-extern "C" fn __truncdfsf2(_x: f64) -> f32 {
-    0.0
-}
-
-

--- a/src/math/frexp.rs
+++ b/src/math/frexp.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn frexp(x: f64) -> (f64, i32) {
+pub fn frexp(x: f64) -> (f64, i32) {
     libm::frexp(x)
 }

--- a/src/math/frexpf.rs
+++ b/src/math/frexpf.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn frexpf(x: f32) -> (f32, i32) {
+pub fn frexpf(x: f32) -> (f32, i32) {
     libm::frexpf(x)
 }

--- a/src/math/lgamma_r.rs
+++ b/src/math/lgamma_r.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn lgamma_r(x: f64) -> (f64, i32) {
+pub fn lgamma_r(x: f64) -> (f64, i32) {
     libm::lgamma_r(x)
 }

--- a/src/math/lgammaf.rs
+++ b/src/math/lgammaf.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn lgammf(x: f32) -> f32 {
+pub fn lgammf(x: f32) -> f32 {
     libm::lgammaf(x)
 }

--- a/src/math/lgammaf_r.rs
+++ b/src/math/lgammaf_r.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn lgammaf_r(x: f32) -> (f32, i32) {
+pub fn lgammaf_r(x: f32) -> (f32, i32) {
     libm::lgammaf_r(x)
 }

--- a/src/math/modf.rs
+++ b/src/math/modf.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn modf(x: f64) -> (f64, f64) {
+pub fn modf(x: f64) -> (f64, f64) {
     libm::modf(x)
 }

--- a/src/math/modff.rs
+++ b/src/math/modff.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn modff(x: f32) -> (f32, f32) {
+pub fn modff(x: f32) -> (f32, f32) {
     libm::modff(x)
 }

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn remquo(x: f64, y: f64) -> (f64, i32) {
+pub fn remquo(x: f64, y: f64) -> (f64, i32) {
     libm::remquo(x, y)
 }

--- a/src/math/remquof.rs
+++ b/src/math/remquof.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn remquof(x: f32, y: f32) -> (f32, i32) {
+pub fn remquof(x: f32, y: f32) -> (f32, i32) {
     libm::remquof(x, y)
 }

--- a/src/math/sincos.rs
+++ b/src/math/sincos.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn sincos(x: f64) -> (f64, f64) {
+pub fn sincos(x: f64) -> (f64, f64) {
     libm::sincos(x)
 }

--- a/src/math/sincosf.rs
+++ b/src/math/sincosf.rs
@@ -8,7 +8,6 @@
  * Copyright (c) 2021 The LibM Team of the HaruxOS Project
  */
 
-#[no_mangle]
-pub extern "C" fn sincosf(x: f32) -> (f32, f32) {
+pub fn sincosf(x: f32) -> (f32, f32) {
     libm::sincosf(x)
 }


### PR DESCRIPTION
`__truncdfsf2()` was causing a duplicate symbol error for me, so I had to remove it.  Also, all the types that return tuples are not "FFI-safe", so I removed the `extern "C"` on those functions.